### PR TITLE
Embed more metadata in events

### DIFF
--- a/lib/riemann/tools/bacula.rb
+++ b/lib/riemann/tools/bacula.rb
@@ -199,6 +199,8 @@ module Riemann
                           'critical'
                         end
         event[:description] = data['Termination']
+        event[:job_name] = data['Job Name']
+        event[:backup_level] = data['Backup Level']
         report(event)
 
         return unless options[:details]
@@ -218,6 +220,8 @@ module Riemann
           event = {}
           event[:service] = "bacula backup #{data['Job Name']} #{data['Backup Level'].downcase} #{metric.downcase}"
           event[:metric] = data[metric]
+          event[:job_name] = data['Job Name']
+          event[:backup_level] = data['Backup Level']
           report(event)
         end
       end

--- a/spec/riemann/tools/bacula_spec.rb
+++ b/spec/riemann/tools/bacula_spec.rb
@@ -432,17 +432,17 @@ RSpec.describe Riemann::Tools::Bacula do
       instance.send_events(parsed_data)
     end
 
-    it { is_expected.to have_received(:report).with(service: 'bacula backup rdc10235a', state: 'ok', description: 'Backup OK') }
+    it { is_expected.to have_received(:report).with(service: 'bacula backup rdc10235a', state: 'ok', description: 'Backup OK', job_name: 'rdc10235a', backup_level: 'Full') }
 
-    it { is_expected.to have_received(:report).with(service: 'bacula backup rdc10235a full elapsed time', metric: 4) }
-    it { is_expected.to have_received(:report).with(service: 'bacula backup rdc10235a full fd files written', metric: 1) }
-    it { is_expected.to have_received(:report).with(service: 'bacula backup rdc10235a full sd files written', metric: 1) }
-    it { is_expected.to have_received(:report).with(service: 'bacula backup rdc10235a full fd bytes written', metric: 6728) }
-    it { is_expected.to have_received(:report).with(service: 'bacula backup rdc10235a full sd bytes written', metric: 6852) }
-    it { is_expected.to have_received(:report).with(service: 'bacula backup rdc10235a full sd errors', metric: 0) }
-    it { is_expected.to have_received(:report).with(service: 'bacula backup rdc10235a full rate', metric: 1.7) }
-    it { is_expected.to have_received(:report).with(service: 'bacula backup rdc10235a full software compression', metric: 0.649) }
-    it { is_expected.to have_received(:report).with(service: 'bacula backup rdc10235a full comm line compression', metric: 0) }
-    it { is_expected.to have_received(:report).with(service: 'bacula backup rdc10235a full non-fatal fd errors', metric: 0) }
+    it { is_expected.to have_received(:report).with(service: 'bacula backup rdc10235a full elapsed time', metric: 4, job_name: 'rdc10235a', backup_level: 'Full') }
+    it { is_expected.to have_received(:report).with(service: 'bacula backup rdc10235a full fd files written', metric: 1, job_name: 'rdc10235a', backup_level: 'Full') }
+    it { is_expected.to have_received(:report).with(service: 'bacula backup rdc10235a full sd files written', metric: 1, job_name: 'rdc10235a', backup_level: 'Full') }
+    it { is_expected.to have_received(:report).with(service: 'bacula backup rdc10235a full fd bytes written', metric: 6728, job_name: 'rdc10235a', backup_level: 'Full') }
+    it { is_expected.to have_received(:report).with(service: 'bacula backup rdc10235a full sd bytes written', metric: 6852, job_name: 'rdc10235a', backup_level: 'Full') }
+    it { is_expected.to have_received(:report).with(service: 'bacula backup rdc10235a full sd errors', metric: 0, job_name: 'rdc10235a', backup_level: 'Full') }
+    it { is_expected.to have_received(:report).with(service: 'bacula backup rdc10235a full rate', metric: 1.7, job_name: 'rdc10235a', backup_level: 'Full') }
+    it { is_expected.to have_received(:report).with(service: 'bacula backup rdc10235a full software compression', metric: 0.649, job_name: 'rdc10235a', backup_level: 'Full') }
+    it { is_expected.to have_received(:report).with(service: 'bacula backup rdc10235a full comm line compression', metric: 0, job_name: 'rdc10235a', backup_level: 'Full') }
+    it { is_expected.to have_received(:report).with(service: 'bacula backup rdc10235a full non-fatal fd errors', metric: 0, job_name: 'rdc10235a', backup_level: 'Full') }
   end
 end


### PR DESCRIPTION
Add the job name and backup level to ease up events management.

This can be used for example to add filters in grafana.