### PR TITLE
Fix how we set the host of bacula events

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In your Bacula Director configuration, add a Message resource like this (the pro
 ```
 Messages {
   Name = Standard
-  MailCommand = "riemann-bacula --client \"%h\" --job-name \"%n\" --backup-level \"%l\" --status \"%e\" --bytes \"%b\" --files \"%F\""
+  MailCommand = "riemann-bacula --event-host \"%h\" --job-name \"%n\" --backup-level \"%l\" --status \"%e\" --bytes \"%b\" --files \"%F\""
   Mail = sysadmin@example.com = all, !skipped
 }
 ```

--- a/lib/riemann/tools/bacula.rb
+++ b/lib/riemann/tools/bacula.rb
@@ -9,7 +9,6 @@ module Riemann
     class Bacula
       include Riemann::Tools
 
-      opt :client,       'File daemon (%h)',     short: :none, type: :string
       opt :job_name,     'Job name (%n)',        short: :none, type: :string
       opt :backup_level, 'Job Level (%l)',       short: :none, type: :string
       opt :status,       'Job Exit Status (%e)', short: :none, type: :string
@@ -24,14 +23,13 @@ module Riemann
       end
 
       def run
-        %i[client job_name backup_level status].each do |name|
+        %i[job_name backup_level status].each do |name|
           raise("Parameter #{name} is required") unless opts[name]
         end
 
         data = parse($stdin.read)
 
         report({
-                 host: opts[:client],
                  service: "bacula backup #{opts[:job_name]}",
                  state: bacula_backup_state,
                  job_name: opts[:job_name],
@@ -43,7 +41,6 @@ module Riemann
           next unless opts[metric]
 
           report({
-                   host: opts[:client],
                    service: "bacula backup #{opts[:job_name]} #{opts[:backup_level].downcase} #{metric}",
                    metric: opts[metric],
                    job_name: opts[:job_name],
@@ -236,7 +233,6 @@ module Riemann
           next unless data[metric]
 
           report({
-                   host: opts[:client],
                    service: "bacula backup #{opts[:job_name]} #{opts[:backup_level].downcase} #{metric.downcase}",
                    metric: data[metric],
                    job_name: opts[:job_name],

--- a/spec/riemann/tools/bacula_spec.rb
+++ b/spec/riemann/tools/bacula_spec.rb
@@ -418,7 +418,6 @@ RSpec.describe Riemann::Tools::Bacula do
 
     before do
       allow(instance).to receive(:report)
-      instance.options[:client] = 'example.com'
       instance.options[:job_name] = 'rdc10235a'
       instance.options[:backup_level] = 'Full'
       instance.options[:status] = 'OK'
@@ -428,9 +427,9 @@ RSpec.describe Riemann::Tools::Bacula do
       instance.run
     end
 
-    it { is_expected.to have_received(:report).with(hash_including(host: 'example.com', service: 'bacula backup rdc10235a', state: 'ok', job_name: 'rdc10235a', backup_level: 'Full')) }
-    it { is_expected.to have_received(:report).with(hash_including(host: 'example.com', service: 'bacula backup rdc10235a full bytes', metric: 13_984, job_name: 'rdc10235a', backup_level: 'Full')) }
-    it { is_expected.to have_received(:report).with(hash_including(host: 'example.com', service: 'bacula backup rdc10235a full files', metric: 42, job_name: 'rdc10235a', backup_level: 'Full')) }
+    it { is_expected.to have_received(:report).with(hash_including(service: 'bacula backup rdc10235a', state: 'ok', job_name: 'rdc10235a', backup_level: 'Full')) }
+    it { is_expected.to have_received(:report).with(hash_including(service: 'bacula backup rdc10235a full bytes', metric: 13_984, job_name: 'rdc10235a', backup_level: 'Full')) }
+    it { is_expected.to have_received(:report).with(hash_including(service: 'bacula backup rdc10235a full files', metric: 42, job_name: 'rdc10235a', backup_level: 'Full')) }
   end
 
   describe '#send_details' do


### PR DESCRIPTION
In #7, we add parameters to more reliably generate bacula events.  The `--client` parameter value is overridden by the `--event-host` parameter when it is set, so remove the --client one and rely on riemann-tools base arguments to set the host.

Because #7 was never released, this is not considered a breaking change.
