### PR TITLE
Fix description of truncated status events

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @opus-codium/core, @opus-codium/vittoria-conseil
+* @opus-codium/core @opus-codium/vittoria-conseil

--- a/lib/riemann/tools/bacula.rb
+++ b/lib/riemann/tools/bacula.rb
@@ -34,7 +34,7 @@ module Riemann
                  state: bacula_backup_state,
                  job_name: opts[:job_name],
                  backup_level: opts[:backup_level],
-                 description: data['Termination'],
+                 description: "#{opts[:status]} (#{data['Termination']})",
                })
 
         %i[bytes files].each do |metric|


### PR DESCRIPTION
When a backup output is truncated, `data['Termination']` is not
available and the status report description might be an empty string.
This is not an issue if the state is 'ok' (corresponding to a
Termination of 'Backup OK') but as any other status result in a
'critical' state, we do not have a feedback on the actual error when
this happen with a trucated message.

Add the status passed as a parameter in the description so that we can
have relevant feedback on error.
