### PR TITLE
Fix warning detection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,11 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in riemann-tools.gemspec
 gemspec
+
+gem 'github_changelog_generator'
+gem 'rake'
+gem 'rspec'
+gem 'rubocop'
+gem 'rubocop-rake'
+gem 'rubocop-rspec'
+gem 'simplecov'

--- a/lib/riemann/tools/bacula.rb
+++ b/lib/riemann/tools/bacula.rb
@@ -54,6 +54,7 @@ module Riemann
       def bacula_backup_state
         case opts[:status]
         when 'OK' then 'ok'
+        when 'OK -- with warnings' then 'warning'
         else
           'critical'
         end

--- a/riemann-bacula.gemspec
+++ b/riemann-bacula.gemspec
@@ -31,12 +31,4 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'riemann-tools', '~> 1.0'
-
-  spec.add_development_dependency 'github_changelog_generator'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rubocop'
-  spec.add_development_dependency 'rubocop-rake'
-  spec.add_development_dependency 'rubocop-rspec'
-  spec.add_development_dependency 'simplecov'
 end


### PR DESCRIPTION
On backup warning (e.g. backup successful but a file disapeared while
copying data), riemann-bacula generates a critical event.

Fix this behavior to generate a warning event.
