### PR TITLE
Do not update canceled backups state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
           - "2.7"
           - "3.0"
           - "3.1"
+          - "3.2"
+          - "3.3"
+          - "3.4"
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v3

--- a/lib/riemann/tools/bacula.rb
+++ b/lib/riemann/tools/bacula.rb
@@ -29,13 +29,15 @@ module Riemann
 
         data = parse($stdin.read)
 
-        report({
-                 service: "bacula backup #{opts[:job_name]}",
-                 state: bacula_backup_state,
-                 job_name: opts[:job_name],
-                 backup_level: opts[:backup_level],
-                 description: "#{opts[:status]} (#{data['Termination']})",
-               })
+        if opts[:status] != 'Canceled'
+          report({
+                   service: "bacula backup #{opts[:job_name]}",
+                   state: bacula_backup_state,
+                   job_name: opts[:job_name],
+                   backup_level: opts[:backup_level],
+                   description: "#{opts[:status]} (#{data['Termination']})",
+                 })
+        end
 
         %i[bytes files].each do |metric|
           next unless opts[metric]

--- a/riemann-bacula.gemspec
+++ b/riemann-bacula.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'riemann-tools', '~> 1.0'
+  spec.add_dependency 'riemann-tools', '~> 1.0'
 end


### PR DESCRIPTION
When a backup is canceled, we do not want to replace the previous state because we do not know if this backup is canceled because terrible things are happening and the administrator does it best to avoid more damage, or because the scheduled backup does not make sense (e.g. wrong host) and the previous backup is perfectly fine.  In any case, the old state will eventually timeout or be replaced with an actual new state at some point in the future.
